### PR TITLE
Use CodeWarrior runtime functions

### DIFF
--- a/clang/lib/CodeGen/ItaniumCXXABI.cpp
+++ b/clang/lib/CodeGen/ItaniumCXXABI.cpp
@@ -515,11 +515,11 @@ public:
       : ItaniumCXXABI(CGM, /*UseARMMethodPtrABI=*/false,
                       /*UseARMGuardVarABI=*/false) {}
 
-  CGCallee MacintoshCXXABI::getVirtualFunctionPointer(CodeGenFunction &CGF,
-                                                      GlobalDecl GD,
-                                                      Address This,
-                                                      llvm::Type *Ty,
-                                                      SourceLocation Loc);
+  CGCallee getVirtualFunctionPointer(CodeGenFunction &CGF,
+                                     GlobalDecl GD,
+                                     Address This,
+                                     llvm::Type *Ty,
+                                     SourceLocation Loc);
 
   llvm::Constant *
   getVTableAddressPoint(BaseSubobject Base,
@@ -545,7 +545,7 @@ public:
     llvm::Function *Fn = CGM.codegenCXXStructor(GD);
     CGM.maybeSetTrivialComdat(*GD.getDecl(), *Fn);
   }
-  
+
   void EmitCXXConstructors(const CXXConstructorDecl *D) override {
     CGM.EmitGlobal(GlobalDecl(D, Ctor_Complete));
   }
@@ -3641,7 +3641,7 @@ void ItaniumRTTIBuilder::BuildVTablePointer(const Type *Ty) {
     // The vtable address point is 8 bytes after its start:
     // 4 for the offset to top + 4 for the relative offset to rtti.
     llvm::Constant *Offset;
-    if (isCodeWarriorABI) 
+    if (isCodeWarriorABI)
       Offset = llvm::ConstantInt::get(CGM.Int32Ty, 0);
     else
       Offset = llvm::ConstantInt::get(CGM.Int32Ty, 8);
@@ -3650,7 +3650,7 @@ void ItaniumRTTIBuilder::BuildVTablePointer(const Type *Ty) {
         llvm::ConstantExpr::getInBoundsGetElementPtr(CGM.Int8Ty, VTable, Offset);
   } else {
     llvm::Constant *Offset;
-    if (isCodeWarriorABI) 
+    if (isCodeWarriorABI)
       Offset = llvm::ConstantInt::get(PtrDiffTy, 0);
     else
       Offset = llvm::ConstantInt::get(PtrDiffTy, 2);
@@ -4986,7 +4986,7 @@ void MacintoshCXXABI::EmitDestructorCall(CodeGenFunction &CGF,
     Callee = CGF.BuildAppleKextVirtualDestructorCall(DD, Type, DD->getParent());
   else
     Callee = CGCallee::forDirect(CGM.getAddrOfCXXStructor(GD), GD);
-  
+
   CGF.EmitCXXDestructorCall(GD, Callee, This.getPointer(), ThisTy, Deleting,
                             DeletingTy, nullptr);
 }

--- a/llvm/include/llvm/ADT/Triple.h
+++ b/llvm/include/llvm/ADT/Triple.h
@@ -803,6 +803,11 @@ public:
            getSubArch() == Triple::AArch64SubArch_arm64e;
   }
 
+  bool isOSCodeWarrior() const {
+    return getArch() == Triple::ppc &&
+           getOS() == Triple::Kuribo;
+  }
+
   /// Tests whether the target supports comdat
   bool supportsCOMDAT() const {
     return !(isOSBinFormatMachO() || isOSBinFormatXCOFF());

--- a/llvm/lib/Target/PowerPC/PPCSubtarget.h
+++ b/llvm/lib/Target/PowerPC/PPCSubtarget.h
@@ -342,6 +342,8 @@ public:
   bool is32BitELFABI() const { return  isSVR4ABI() && !isPPC64(); }
   bool isUsingPCRelativeCalls() const;
 
+  bool isCodeWarrior() const { return TargetTriple.isOSCodeWarrior(); }
+
   /// Originally, this function return hasISEL(). Now we always enable it,
   /// but may expand the ISEL instruction later.
   bool enableEarlyIfConversion() const override { return true; }


### PR DESCRIPTION
Overrides some compiler-rt libcalls with CW runtime functions.

Output is nearly equivalent to MWCC:

![Screenshot from 2022-08-23 11-14-14](https://user-images.githubusercontent.com/549122/186220177-01f8cc7c-10cf-4623-8eaa-891acdaca359.png)

More functions can be added as needed.