### PR TITLE
Fix vtable placement in subclasses

### DIFF
--- a/clang/include/clang/AST/VTableBuilder.h
+++ b/clang/include/clang/AST/VTableBuilder.h
@@ -360,7 +360,7 @@ public:
 };
 
 class ItaniumVTableContext : public VTableContextBase {
-private:
+protected:
 
   /// Contains the index (relative to the vtable address point)
   /// where the function pointer for a virtual function is stored.
@@ -437,6 +437,16 @@ public:
 
 private:
   VTableComponentLayout ComponentLayout;
+};
+
+class CodeWarriorVTableContext : public ItaniumVTableContext {
+private:
+  void computeVTableRelatedInformation(const CXXRecordDecl *RD) override;
+
+public:
+  CodeWarriorVTableContext(ASTContext &Context,
+                           VTableComponentLayout ComponentLayout = Pointer);
+  ~CodeWarriorVTableContext() override;
 };
 
 /// Holds information about the inheritance path to a virtual base or function

--- a/clang/include/clang/Basic/TargetCXXABI.h
+++ b/clang/include/clang/Basic/TargetCXXABI.h
@@ -33,12 +33,13 @@ public:
     ///   http://www.codesourcery.com/public/cxx-abi/
     GenericItanium,
         
-    /// The generic Itanium ABI is the standard ABI of most open-source
-    /// and Unix-like platforms.  It is the primary ABI targeted by
-    /// many compilers, including Clang and GCC.
+    /// The legacy Macintosh ABI as specialized by the toolchain CodeWarrior.
+    /// This is utilized for older Nintendo games targeted for the GameCube and Wii.
     ///
-    /// It is documented here:
-    ///   http://www.codesourcery.com/public/cxx-abi/
+    /// Differences from the Itanium ABI include:
+    ///   - declaration order dependant object VTable offsets
+    ///   - non-variant constructors and multi-purpose destructors
+    ///   - specialized symbol mangling
     CodeWarrior,
     /// The generic ARM ABI is a modified version of the Itanium ABI
     /// proposed by ARM for use on ARM-based platforms.

--- a/clang/lib/AST/ASTContext.cpp
+++ b/clang/lib/AST/ASTContext.cpp
@@ -10862,7 +10862,10 @@ VTableContextBase *ASTContext::getVTableContext() {
       auto ComponentLayout = getLangOpts().RelativeCXXABIVTables
                                  ? ItaniumVTableContext::Relative
                                  : ItaniumVTableContext::Pointer;
-      VTContext.reset(new ItaniumVTableContext(*this, ComponentLayout));
+      if (Target->getCXXABI() == TargetCXXABI::CodeWarrior)
+        VTContext.reset(new CodeWarriorVTableContext(*this, ComponentLayout));
+      else
+        VTContext.reset(new ItaniumVTableContext(*this, ComponentLayout));
     }
   }
   return VTContext.get();

--- a/clang/lib/AST/MacintoshMangle.cpp
+++ b/clang/lib/AST/MacintoshMangle.cpp
@@ -1,5 +1,4 @@
-//===--- MacintoshMangle.cpp - Macintosh C++ Name Mangling
-//-------------------------------*- C++ -*-===//
+//===--- MacintoshMangle.cpp - Macintosh C++ Name Mangling -------------------------------*- C++ -*-===//
 //
 // Part of the LLVM Project, under the Apache License v2.0 with LLVM Exceptions.
 // See https://llvm.org/LICENSE.txt for license information.
@@ -15,6 +14,7 @@
 //
 //===-----------------------------------------------------------------------------------------------===//
 
+#include "clang/AST/Mangle.h"
 #include "clang/AST/ASTContext.h"
 #include "clang/AST/Attr.h"
 #include "clang/AST/Decl.h"
@@ -26,7 +26,6 @@
 #include "clang/AST/Expr.h"
 #include "clang/AST/ExprCXX.h"
 #include "clang/AST/ExprObjC.h"
-#include "clang/AST/Mangle.h"
 #include "clang/AST/TypeLoc.h"
 #include "clang/Basic/ABI.h"
 #include "clang/Basic/SourceManager.h"
@@ -34,6 +33,8 @@
 #include "llvm/ADT/StringExtras.h"
 #include "llvm/Support/ErrorHandling.h"
 #include "llvm/Support/raw_ostream.h"
+
+
 
 using namespace clang;
 
@@ -50,15 +51,15 @@ static const DeclContext *getEffectiveDeclContext(const Decl *D) {
   // had not yet been created. Fix the context here.
   if (const CXXRecordDecl *RD = dyn_cast<CXXRecordDecl>(D)) {
     if (RD->isLambda())
-      if (ParmVarDecl *ContextParam =
-              dyn_cast_or_null<ParmVarDecl>(RD->getLambdaContextDecl()))
+      if (ParmVarDecl *ContextParam
+            = dyn_cast_or_null<ParmVarDecl>(RD->getLambdaContextDecl()))
         return ContextParam->getDeclContext();
   }
 
   // Perform the same check for block literals.
   if (const BlockDecl *BD = dyn_cast<BlockDecl>(D)) {
-    if (ParmVarDecl *ContextParam =
-            dyn_cast_or_null<ParmVarDecl>(BD->getBlockManglingContextDecl()))
+    if (ParmVarDecl *ContextParam
+          = dyn_cast_or_null<ParmVarDecl>(BD->getBlockManglingContextDecl()))
       return ContextParam->getDeclContext();
   }
 
@@ -130,7 +131,9 @@ public:
   /// @{
 
   bool shouldMangleCXXName(const NamedDecl *D);
-  bool shouldMangleStringLiteral(const StringLiteral *) { return false; }
+  bool shouldMangleStringLiteral(const StringLiteral *) {
+    return false;
+  }
   void mangleCXXName(GlobalDecl GD, raw_ostream &) override;
   void mangleThunk(const CXXMethodDecl *MD, const ThunkInfo &Thunk,
                    raw_ostream &) override;
@@ -149,23 +152,29 @@ public:
 
   void mangleStaticGuardVariable(const VarDecl *D, raw_ostream &);
   void mangleDynamicInitializer(const VarDecl *D, raw_ostream &Out);
-  void mangleDynamicAtExitDestructor(const VarDecl *D, raw_ostream &Out);
+  void mangleDynamicAtExitDestructor(const VarDecl *D,
+                                     raw_ostream &Out);
   void mangleSEHFilterExpression(const NamedDecl *EnclosingDecl,
                                  raw_ostream &Out);
-  void mangleSEHFinallyBlock(const NamedDecl *EnclosingDecl, raw_ostream &Out);
+  void mangleSEHFinallyBlock(const NamedDecl *EnclosingDecl,
+                             raw_ostream &Out);
 
   void mangleStringLiteral(const StringLiteral *, raw_ostream &);
 
   void mangleCXXVTable(const CXXRecordDecl *RD, raw_ostream &) override;
   void mangleCXXVTT(const CXXRecordDecl *RD, raw_ostream &) override;
   void mangleCXXCtorVTable(const CXXRecordDecl *RD, int64_t Offset,
-                           const CXXRecordDecl *Type, raw_ostream &) override;
-  void mangleItaniumThreadLocalInit(const VarDecl *D, raw_ostream &) override;
+                           const CXXRecordDecl *Type,
+                           raw_ostream &) override;
+  void mangleItaniumThreadLocalInit(const VarDecl *D,
+                                    raw_ostream &) override;
   void mangleItaniumThreadLocalWrapper(const VarDecl *D,
                                        raw_ostream &) override;
 
-  void mangleCXXCtorComdat(const CXXConstructorDecl *D, raw_ostream &) override;
-  void mangleCXXDtorComdat(const CXXDestructorDecl *D, raw_ostream &) override;
+  void mangleCXXCtorComdat(const CXXConstructorDecl *D,
+                           raw_ostream &) override;
+  void mangleCXXDtorComdat(const CXXDestructorDecl *D,
+                           raw_ostream &) override;
 
   void mangleLambdaSig(const CXXRecordDecl *Lambda, raw_ostream &Out) override;
   void mangleDynamicStermFinalizer(const VarDecl *D, raw_ostream &Out) override;
@@ -202,7 +211,7 @@ public:
   /// @}
 };
 
-} // namespace
+}
 
 bool MacintoshMangleContextImpl::shouldMangleCXXName(const NamedDecl *D) {
   const FunctionDecl *FD = dyn_cast<FunctionDecl>(D);
@@ -257,7 +266,8 @@ bool MacintoshMangleContextImpl::shouldMangleCXXName(const NamedDecl *D) {
   return true;
 }
 
-static bool PrintType(QualType T, const ASTContext &Ctx, raw_ostream &Out);
+static bool PrintType(QualType T, const ASTContext &Ctx,
+                      raw_ostream &Out);
 
 static void MangleTemplateSpecializationArg(const TemplateArgument &Arg,
                                             bool &NeedsComma,
@@ -276,8 +286,7 @@ static void MangleTemplateSpecializationArg(const TemplateArgument &Arg,
     Arg.getAsIntegral().print(Out, true);
     NeedsComma = true;
     break;
-  default:
-    break;
+  default: break;
   }
 }
 
@@ -304,184 +313,12 @@ static void MangleTemplateSpecialization(
   Out << '>';
 }
 
-static void MangleTemplateParamDecl(const NamedDecl *Decl,
-                                    const ASTContext &Ctx, raw_ostream &Out) {
-  if (auto *Ty = dyn_cast<TemplateTypeParmDecl>(Decl)) {
-    if (Ty->isParameterPack())
-      Out << "Tp";
-    Out << "Ty";
-  } else if (auto *Tn = dyn_cast<NonTypeTemplateParmDecl>(Decl)) {
-    if (Tn->isExpandedParameterPack()) {
-      for (unsigned I = 0, N = Tn->getNumExpansionTypes(); I != N; ++I) {
-        Out << "Tn";
-        PrintType(Tn->getExpansionType(I), Ctx, Out);
-      }
-    } else {
-      QualType T = Tn->getType();
-      if (Tn->isParameterPack()) {
-        Out << "Tp";
-        if (auto *PackExpansion = T->getAs<PackExpansionType>())
-          T = PackExpansion->getPattern();
-      }
-      Out << "Tn";
-      PrintType(T, Ctx, Out);
-    }
-  } else if (auto *Tt = dyn_cast<TemplateTemplateParmDecl>(Decl)) {
-    if (Tt->isExpandedParameterPack()) {
-      for (unsigned I = 0, N = Tt->getNumExpansionTemplateParameters(); I != N;
-           ++I) {
-        Out << "Tt";
-        for (auto *Param : *Tt->getExpansionTemplateParameters(I))
-          MangleTemplateParamDecl(Param, Ctx, Out);
-        Out << "E";
-      }
-    } else {
-      if (Tt->isParameterPack())
-        Out << "Tp";
-      Out << "Tt";
-      for (auto *Param : *Tt->getTemplateParameters())
-        MangleTemplateParamDecl(Param, Ctx, Out);
-      Out << "E";
-    }
-  }
-}
-
-class FunctionTypeDepthState {
-  unsigned Bits;
-
-  enum { InResultTypeMask = 1 };
-
-public:
-  FunctionTypeDepthState() : Bits(0) {}
-
-  /// The number of function types we're inside.
-  unsigned getDepth() const { return Bits >> 1; }
-
-  /// True if we're in the return type of the innermost function type.
-  bool isInResultType() const { return Bits & InResultTypeMask; }
-
-  FunctionTypeDepthState push() {
-    FunctionTypeDepthState tmp = *this;
-    Bits = (Bits & ~InResultTypeMask) + 2;
-    return tmp;
-  }
-
-  void enterResultType() { Bits |= InResultTypeMask; }
-
-  void leaveResultType() { Bits &= ~InResultTypeMask; }
-
-  void pop(FunctionTypeDepthState saved) {
-    assert(getDepth() == saved.getDepth() + 1);
-    Bits = saved.Bits;
-  }
-};
-
-static FunctionTypeDepthState FunctionTypeDepth;
-
-void mangleVendorQualifier(StringRef name, raw_ostream &Out) {
-  Out << 'U' << name.size() << name;
-}
-
-void mangleExtParameterInfo(FunctionProtoType::ExtParameterInfo PI,
-                            const ASTContext &Ctx, raw_ostream &Out) {
-  // Vendor-specific qualifiers are emitted in reverse alphabetical order.
-
-  // Note that these are *not* substitution candidates.  Demanglers might
-  // have trouble with this if the parameter type is fully substituted.
-
-  switch (PI.getABI()) {
-  case ParameterABI::Ordinary:
-    break;
-
-  // All of these start with "swift", so they come before "ns_consumed".
-  case ParameterABI::SwiftContext:
-  case ParameterABI::SwiftErrorResult:
-  case ParameterABI::SwiftIndirectResult:
-    mangleVendorQualifier(getParameterABISpelling(PI.getABI()), Out);
-    break;
-  }
-
-  if (PI.isConsumed())
-    mangleVendorQualifier("ns_consumed", Out);
-
-  if (PI.isNoEscape())
-    mangleVendorQualifier("noescape", Out);
-}
-
-static void MangleBareFunctionType(const FunctionProtoType *Proto,
-                                   bool MangleReturnType,
-                                   const FunctionDecl *FD,
-                                   const ASTContext &Ctx, raw_ostream &Out) {
-  // Record that we're in a function type.  See mangleFunctionParam
-  // for details on what we're trying to achieve here.
-  FunctionTypeDepthState saved = FunctionTypeDepth.push();
-
-  // <bare-function-type> ::= <signature type>+
-  if (MangleReturnType) {
-    FunctionTypeDepth.enterResultType();
-
-    // Mangle ns_returns_retained as an order-sensitive qualifier here.
-    if (Proto->getExtInfo().getProducesResult() && FD == nullptr)
-      Out << 'U' << StringRef("ns_returns_retained").size()
-          << "ns_returns_retained";
-
-    // Mangle the return type without any direct ARC ownership qualifiers.
-    QualType ReturnTy = Proto->getReturnType();
-    if (ReturnTy.getObjCLifetime()) {
-      auto SplitReturnTy = ReturnTy.split();
-      SplitReturnTy.Quals.removeObjCLifetime();
-      ReturnTy = Ctx.getQualifiedType(SplitReturnTy);
-    }
-    PrintType(ReturnTy, Ctx, Out);
-
-    FunctionTypeDepth.leaveResultType();
-  }
-
-  if (Proto->getNumParams() == 0 && !Proto->isVariadic()) {
-    //   <builtin-type> ::= v   # void
-    Out << 'v';
-
-    FunctionTypeDepth.pop(saved);
-    return;
-  }
-
-  assert(!FD || FD->getNumParams() == Proto->getNumParams());
-  for (unsigned I = 0, E = Proto->getNumParams(); I != E; ++I) {
-    // Mangle extended parameter info as order-sensitive qualifiers here.
-    if (Proto->hasExtParameterInfos() && FD == nullptr) {
-      mangleExtParameterInfo(Proto->getExtParameterInfo(I), Ctx, Out);
-    }
-
-    // Mangle the type.
-    QualType ParamTy = Proto->getParamType(I);
-    PrintType(Ctx.getSignatureParameterType(ParamTy), Ctx, Out);
-
-    if (FD) {
-      if (auto *Attr = FD->getParamDecl(I)->getAttr<PassObjectSizeAttr>()) {
-        // Attr can only take 1 character, so we can hardcode the length below.
-        assert(Attr->getType() <= 9 && Attr->getType() >= 0);
-        if (Attr->isDynamic())
-          Out << "U25pass_dynamic_object_size" << Attr->getType();
-        else
-          Out << "U17pass_object_size" << Attr->getType();
-      }
-    }
-  }
-
-  FunctionTypeDepth.pop(saved);
-
-  // <builtin-type>      ::= z  # ellipsis
-  if (Proto->isVariadic())
-    Out << 'e';
-}
-
 static void MangleClassTemplateSpecialization(const Decl *Decl,
                                               const ASTContext &Ctx,
                                               raw_ostream &Out) {
   if (const ClassTemplateSpecializationDecl *TemplateSpec =
-          dyn_cast<ClassTemplateSpecializationDecl>(Decl)) {
-    const TemplateArgumentList &List =
-        TemplateSpec->getTemplateInstantiationArgs();
+      dyn_cast<ClassTemplateSpecializationDecl>(Decl)) {
+    const TemplateArgumentList &List = TemplateSpec->getTemplateInstantiationArgs();
     MangleTemplateSpecialization(List, Ctx, Out);
   }
 }
@@ -506,8 +343,10 @@ static void PrintNameSpace(const NamedDecl *ND, const ASTContext &Ctx,
   Out << NameStr.length() << NameStr;
 }
 
-static void RecursiveDenest(const DeclContext *DCtx, unsigned Count,
-                            const ASTContext &Ctx, raw_ostream &Out) {
+static void RecursiveDenest(const DeclContext *DCtx,
+                            unsigned Count,
+                            const ASTContext &Ctx,
+                            raw_ostream &Out) {
   const NamedDecl *Named = dyn_cast<NamedDecl>(DCtx);
   if (!Named)
     return;
@@ -515,18 +354,19 @@ static void RecursiveDenest(const DeclContext *DCtx, unsigned Count,
   if (Prefix && isa<NamedDecl>(Prefix))
     RecursiveDenest(Prefix, Count + 1, Ctx, Out);
   else if (Count > 1)
-    Out << 'Q' << Count;
-
-  if (DCtx->isNamespace()) {
-    PrintNameSpace(Named, Ctx, Out);
-  } else {
-    PrintNamedDecl(Named, Ctx, Out);
-  }
+		Out << 'Q' << Count;
+    
+	if(DCtx->isNamespace()){
+		PrintNameSpace(Named, Ctx, Out);
+	}else{
+		PrintNamedDecl(Named, Ctx, Out);
+	}
 }
 
-static bool PrintType(QualType T, const ASTContext &Ctx, raw_ostream &Out) {
-  if (const ConstantArrayType *Array = dyn_cast_or_null<ConstantArrayType>(
-          T.getTypePtr()->getAsArrayTypeUnsafe())) {
+static bool PrintType(QualType T, const ASTContext &Ctx,
+                      raw_ostream &Out) {
+  if (const ConstantArrayType *Array =
+      dyn_cast_or_null<ConstantArrayType>(T.getTypePtr()->getAsArrayTypeUnsafe())) {
     Out << 'A';
     Array->getSize().print(Out, false);
     Out << '_';
@@ -552,16 +392,14 @@ static bool PrintType(QualType T, const ASTContext &Ctx, raw_ostream &Out) {
     PrintNamedDecl(TD, Ctx, Out);
     return true;
 
-  } else if (const MemberPointerType *MemberPtr =
-                 T.getTypePtr()->getAs<MemberPointerType>()) {
+  } else if (const MemberPointerType *MemberPtr = T.getTypePtr()->getAs<MemberPointerType>()) {
     Out << 'M';
     const RecordType *Rec = dyn_cast<RecordType>(MemberPtr->getClass());
     if (Rec)
       RecursiveDenest(Rec->getDecl(), 1, Ctx, Out);
     return PrintType(MemberPtr->getPointeeType(), Ctx, Out);
 
-  } else if (const FunctionProtoType *Proto =
-                 T.getTypePtr()->getAs<FunctionProtoType>()) {
+  } else if (const FunctionProtoType *Proto = T.getTypePtr()->getAs<FunctionProtoType>()) {
     Out << 'F';
     if (!Proto->getNumParams() && !Proto->isVariadic())
       Out << 'v';
@@ -576,8 +414,7 @@ static bool PrintType(QualType T, const ASTContext &Ctx, raw_ostream &Out) {
     PrintType(Proto->getReturnType(), Ctx, Out);
     return true;
 
-  } else if (const BuiltinType *Builtin =
-                 T.getTypePtr()->getAs<BuiltinType>()) {
+  } else if (const BuiltinType *Builtin = T.getTypePtr()->getAs<BuiltinType>()) {
     switch (Builtin->getKind()) {
     case BuiltinType::Void:
       Out << 'v';
@@ -630,8 +467,7 @@ static bool PrintType(QualType T, const ASTContext &Ctx, raw_ostream &Out) {
     case BuiltinType::LongDouble:
       Out << 'r';
       return true;
-    default:
-      break;
+    default: break;
     }
   }
   return false;
@@ -656,207 +492,121 @@ static void MangleCallOffset(int64_t NonVirtual, int64_t Virtual,
 
 static void MangleOperatorName(OverloadedOperatorKind OO, raw_ostream &Out) {
   Out << "__";
-
+  
   switch (OO) {
   // <operator-name> ::= nw     # new
-  case OO_New:
-    Out << "nw";
-    break;
+  case OO_New: Out << "nw"; break;
   //              ::= nwa       # new[]
-  case OO_Array_New:
-    Out << "nwa";
-    break;
+  case OO_Array_New: Out << "nwa"; break;
   //              ::= dl        # delete
-  case OO_Delete:
-    Out << "dl";
-    break;
+  case OO_Delete: Out << "dl"; break;
   //              ::= dla       # delete[]
-  case OO_Array_Delete:
-    Out << "dla";
-    break;
+  case OO_Array_Delete: Out << "dla"; break;
   //              ::= pl        # +
   case OO_Plus:
-    Out << "pl";
-    break;
+    Out << "pl"; break;
   //              ::= mi        # -
   case OO_Minus:
-    Out << "mi";
-    break;
+    Out << "mi"; break;
   //              ::= ml        # *
   case OO_Star:
-    Out << "ml";
-    break;
+    Out << "ml"; break;
   //              ::= dv        # /
-  case OO_Slash:
-    Out << "dv";
-    break;
+  case OO_Slash: Out << "dv"; break;
   //              ::= md        # %
-  case OO_Percent:
-    Out << "md";
-    break;
+  case OO_Percent: Out << "md"; break;
   //              ::= er        # ^
-  case OO_Caret:
-    Out << "er";
-    break;
+  case OO_Caret: Out << "er"; break;
   //              ::= adv       # /=
-  case OO_SlashEqual:
-    Out << "adv";
-    break;
+  case OO_SlashEqual: Out << "adv"; break;
   //              ::= ad        # &
   case OO_Amp:
-    Out << "ad";
-    break;
+    Out << "ad"; break;
   //              ::= or        # |
-  case OO_Pipe:
-    Out << "or";
-    break;
+  case OO_Pipe: Out << "or"; break;
   //              ::= co        # ~
-  case OO_Tilde:
-    Out << "co";
-    break;
+  case OO_Tilde: Out << "co"; break;
   //              ::= nt        # !
-  case OO_Exclaim:
-    Out << "nt";
-    break;
+  case OO_Exclaim: Out << "nt"; break;
   //              ::= as        # =
-  case OO_Equal:
-    Out << "as";
-    break;
+  case OO_Equal: Out << "as"; break;
   //              ::= lt        # <
-  case OO_Less:
-    Out << "lt";
-    break;
+  case OO_Less: Out << "lt"; break;
   //              ::= gt        # >
-  case OO_Greater:
-    Out << "gt";
-    break;
+  case OO_Greater: Out << "gt"; break;
   //              ::= apl       # +=
-  case OO_PlusEqual:
-    Out << "apl";
-    break;
+  case OO_PlusEqual: Out << "apl"; break;
   //              ::= ami       # -=
-  case OO_MinusEqual:
-    Out << "mI";
-    break;
+  case OO_MinusEqual: Out << "mI"; break;
   //              ::= aml       # *=
-  case OO_StarEqual:
-    Out << "aml";
-    break;
+  case OO_StarEqual: Out << "aml"; break;
   //              ::= amd       # %=
-  case OO_PercentEqual:
-    Out << "amd";
-    break;
+  case OO_PercentEqual: Out << "amd"; break;
   //              ::= aer       # ^=
-  case OO_CaretEqual:
-    Out << "aer";
-    break;
+  case OO_CaretEqual: Out << "aer"; break;
   //              ::= aad       # &=
-  case OO_AmpEqual:
-    Out << "aad";
-    break;
+  case OO_AmpEqual: Out << "aad"; break;
   //              ::= aor       # |=
-  case OO_PipeEqual:
-    Out << "aor";
-    break;
+  case OO_PipeEqual: Out << "aor"; break;
   //              ::= ls        # <<
-  case OO_LessLess:
-    Out << "ls";
-    break;
+  case OO_LessLess: Out << "ls"; break;
   //              ::= rs        # >>
-  case OO_GreaterGreater:
-    Out << "rs";
-    break;
+  case OO_GreaterGreater: Out << "rs"; break;
   //              ::= ars       # >>=
-  case OO_GreaterGreaterEqual:
-    Out << "ars";
-    break;
+  case OO_GreaterGreaterEqual: Out << "ars"; break;
   //              ::= als       # <<=
-  case OO_LessLessEqual:
-    Out << "als";
-    break;
+  case OO_LessLessEqual: Out << "als"; break;
 
   //              ::= eq        # ==
-  case OO_EqualEqual:
-    Out << "eq";
-    break;
+  case OO_EqualEqual: Out << "eq"; break;
   //              ::= ne        # !=
-  case OO_ExclaimEqual:
-    Out << "ne";
-    break;
-
+  case OO_ExclaimEqual: Out << "ne"; break;
+  
   //              ::= le        # <=
-  case OO_LessEqual:
-    Out << "le";
-    break;
+  case OO_LessEqual: Out << "le"; break;
   //              ::= ge        # >=
-  case OO_GreaterEqual:
-    Out << "ge";
-    break;
+  case OO_GreaterEqual: Out << "ge"; break;
 
   //              ::= aa        # &&
-  case OO_AmpAmp:
-    Out << "aa";
-    break;
+  case OO_AmpAmp: Out << "aa"; break;
   //              ::= oo        # ||
-  case OO_PipePipe:
-    Out << "oo";
-    break;
+  case OO_PipePipe: Out << "oo"; break;
   //              ::= pp        # ++
-  case OO_PlusPlus:
-    Out << "pp";
-    break;
+  case OO_PlusPlus: Out << "pp"; break;
   //              ::= mm        # --
-  case OO_MinusMinus:
-    Out << "mm";
-    break;
+  case OO_MinusMinus: Out << "mm"; break;
 
   //              ::= cl        # ()
-  case OO_Call:
-    Out << "cl";
-    break;
+  case OO_Call: Out << "cl"; break;
   //              ::= vc        # []
-  case OO_Subscript:
-    Out << "vc";
-    break;
+  case OO_Subscript: Out << "vc"; break;
   //              ::= rf        # ->
-  case OO_Arrow:
-    Out << "rf";
-    break;
+  case OO_Arrow: Out << "rf"; break;
   //              ::= cm        # ,
-  case OO_Comma:
-    Out << "cm";
-    break;
+  case OO_Comma: Out << "cm"; break;
   //              ::= rm        # ->*
-  case OO_ArrowStar:
-    Out << "rm";
-    break;
-
+  case OO_ArrowStar: Out << "rm"; break;
+  
   //              ::= qu        # ?
   // The conditional operator can't be overloaded, but we still handle it when
   // mangling expressions.
-  case OO_Conditional:
-    Out << "qu";
-    break;
+  case OO_Conditional: Out << "qu"; break;
 
-  // The following cases aren't specified by the Macintosh ABI or PowerPC EABI
-  // specifications:
+  // The following cases aren't specified by the Macintosh ABI or PowerPC EABI specifications:
 
   // Proposal on cxx-abi-dev, 2015-10-21.
   //              ::= aw        # co_await
-  case OO_Coawait:
-    Out << "aw";
-    break;
+  case OO_Coawait: Out << "aw"; break;
   // Proposed in cxx-abi github issue 43.
   //              ::= ss        # <=>
-  case OO_Spaceship:
-    Out << "ss";
-    break;
+  case OO_Spaceship: Out << "ss"; break;
 
   case OO_None:
   case NUM_OVERLOADED_OPERATORS:
     llvm_unreachable("Not an overloaded operator");
   }
 }
+
 
 static void MangleOperatorName(DeclarationName Name, raw_ostream &Out) {
   switch (Name.getNameKind()) {
@@ -881,6 +631,8 @@ static void MangleOperatorName(DeclarationName Name, raw_ostream &Out) {
   }
 }
 
+
+
 /// Mangles the name of the declaration D and emits that name to the given
 /// output stream.
 ///
@@ -893,7 +645,7 @@ void MacintoshMangleContextImpl::mangleCXXName(GlobalDecl GD,
                                                raw_ostream &Out) {
   const NamedDecl *D = cast<NamedDecl>(GD.getDecl());
   assert((isa<FunctionDecl>(D) || isa<VarDecl>(D)) &&
-         "Invalid mangleName() call, argument is not a variable or function!");
+          "Invalid mangleName() call, argument is not a variable or function!");
 
   PrettyStackTraceDecl CrashInfo(D, SourceLocation(),
                                  getASTContext().getSourceManager(),
@@ -905,18 +657,18 @@ void MacintoshMangleContextImpl::mangleCXXName(GlobalDecl GD,
       Out << "__ct";
     else if (isa<CXXDestructorDecl>(D))
       Out << "__dt";
-    else if (MD->getNameInfo().getName().getNameKind() ==
-             DeclarationName::CXXOperatorName)
+    else if (MD->getNameInfo().getName().getNameKind() == DeclarationName::CXXOperatorName)
       MangleOperatorName(MD->getNameInfo().getName(), Out);
     else
       MD->getNameInfo().printName(Out, PrintingPolicy(LangOptions()));
     if (const TemplateArgumentList *TArgs = MD->getTemplateSpecializationArgs())
       MangleTemplateSpecialization(*TArgs, getASTContext(), Out);
     else if (DependentFunctionTemplateSpecializationInfo *DepArgs =
-                 MD->getDependentSpecializationInfo())
+             MD->getDependentSpecializationInfo())
       MangleTemplateSpecialization(*DepArgs, getASTContext(), Out);
     Out << "__";
-    RecursiveDenest(getEffectiveDeclContext(MD), 1, getASTContext(), Out);
+    RecursiveDenest(getEffectiveDeclContext(MD), 1,
+                    getASTContext(), Out);
     if (MD->isConst())
       Out << 'C';
     Out << 'F';
@@ -932,18 +684,18 @@ void MacintoshMangleContextImpl::mangleCXXName(GlobalDecl GD,
 
   } else if (const FunctionDecl *FD = dyn_cast<FunctionDecl>(D)) {
     FD = FD->getCanonicalDecl();
-    if (FD->getNameInfo().getName().getNameKind() ==
-        DeclarationName::CXXOperatorName)
+    if (FD->getNameInfo().getName().getNameKind() == DeclarationName::CXXOperatorName)
       MangleOperatorName(FD->getNameInfo().getName(), Out);
     else
       FD->getNameInfo().printName(Out, PrintingPolicy(LangOptions()));
     if (const TemplateArgumentList *TArgs = FD->getTemplateSpecializationArgs())
       MangleTemplateSpecialization(*TArgs, getASTContext(), Out);
     else if (DependentFunctionTemplateSpecializationInfo *DepArgs =
-                 FD->getDependentSpecializationInfo())
+             FD->getDependentSpecializationInfo())
       MangleTemplateSpecialization(*DepArgs, getASTContext(), Out);
     Out << "__";
-    RecursiveDenest(getEffectiveDeclContext(FD), 1, getASTContext(), Out);
+    RecursiveDenest(getEffectiveDeclContext(FD), 1,
+                    getASTContext(), Out);
     Out << 'F';
 
     if (FD->param_empty() && !FD->isVariadic())
@@ -959,7 +711,9 @@ void MacintoshMangleContextImpl::mangleCXXName(GlobalDecl GD,
     VD = VD->getCanonicalDecl();
     Out << VD->getName();
     Out << "__";
-    RecursiveDenest(getEffectiveDeclContext(VD), 1, getASTContext(), Out);
+    RecursiveDenest(getEffectiveDeclContext(VD), 1,
+                    getASTContext(), Out);
+
   }
 }
 
@@ -990,22 +744,26 @@ void MacintoshMangleContextImpl::mangleThunk(const CXXMethodDecl *MD,
 
   // Mangle the 'this' pointer adjustment.
   MangleCallOffset(Thunk.This.NonVirtual,
-                   Thunk.This.Virtual.Itanium.VCallOffsetOffset, Out);
+                   Thunk.This.Virtual.Itanium.VCallOffsetOffset,
+                   Out);
 
   // Mangle the return pointer adjustment if there is one.
   if (!Thunk.Return.isEmpty())
     MangleCallOffset(Thunk.Return.NonVirtual,
-                     Thunk.Return.Virtual.Itanium.VBaseOffsetOffset, Out);
+                     Thunk.Return.Virtual.Itanium.VBaseOffsetOffset,
+                     Out);
 
   mangleCXXName(GlobalDecl(MD), Out);
 }
 
-void MacintoshMangleContextImpl::mangleCXXDtorThunk(
-    const CXXDestructorDecl *DD, CXXDtorType Type,
-    const ThisAdjustment &ThisAdjustment, raw_ostream &Out) {
+void MacintoshMangleContextImpl::mangleCXXDtorThunk(const CXXDestructorDecl *DD,
+                                                    CXXDtorType Type,
+                                                    const ThisAdjustment &ThisAdjustment,
+                                                    raw_ostream &Out) {
   // Mangle the 'this' pointer adjustment.
   MangleCallOffset(ThisAdjustment.NonVirtual,
-                   ThisAdjustment.Virtual.Itanium.VCallOffsetOffset, Out);
+                   ThisAdjustment.Virtual.Itanium.VCallOffsetOffset,
+                   Out);
   mangleCXXName(GlobalDecl(DD, Type), Out);
 }
 
@@ -1023,8 +781,8 @@ void MacintoshMangleContextImpl::mangleDynamicInitializer(const VarDecl *MD,
   Out << "__cxx_global_var_init";
 }
 
-void MacintoshMangleContextImpl::mangleDynamicAtExitDestructor(
-    const VarDecl *D, raw_ostream &Out) {
+void MacintoshMangleContextImpl::mangleDynamicAtExitDestructor(const VarDecl *D,
+                                                               raw_ostream &Out) {
   // Prefix the mangling of D with __dtor_.
   Out << "__dtor_";
   if (shouldMangleDeclName(D)) {
@@ -1048,8 +806,9 @@ void MacintoshMangleContextImpl::mangleSEHFinallyBlock(
     Out << EnclosingDecl->getName();
 }
 
-void MacintoshMangleContextImpl::mangleReferenceTemporary(
-    const VarDecl *D, unsigned ManglingNumber, raw_ostream &Out) {
+void MacintoshMangleContextImpl::mangleReferenceTemporary(const VarDecl *D,
+                                                          unsigned ManglingNumber,
+                                                          raw_ostream &Out) {
   llvm_unreachable("Can't mangle ReferenceTemporary");
 }
 
@@ -1062,8 +821,7 @@ void MacintoshMangleContextImpl::mangleCXXRTTI(QualType Ty, raw_ostream &Out) {
 
 void MacintoshMangleContextImpl::mangleCXXRTTIName(QualType Ty,
                                                    raw_ostream &Out) {
-  // <special-name> ::= RTTS <type>  # typeinfo name (null terminated byte
-  // string)
+  // <special-name> ::= RTTS <type>  # typeinfo name (null terminated byte string)
   Out << "__RTTS__";
   PrintType(Ty, getASTContext(), Out);
 }
@@ -1072,32 +830,31 @@ void MacintoshMangleContextImpl::mangleTypeName(QualType Ty, raw_ostream &Out) {
   mangleCXXRTTIName(Ty, Out);
 }
 
-void MacintoshMangleContextImpl::mangleStringLiteral(const StringLiteral *,
-                                                     raw_ostream &) {
+void MacintoshMangleContextImpl::mangleStringLiteral(
+    const StringLiteral *, raw_ostream &) {
   llvm_unreachable("Can't mangle string literals");
 }
 
-void MacintoshMangleContextImpl::mangleCXXVTable(const CXXRecordDecl *RD,
-                                                 raw_ostream &Out) {
+void MacintoshMangleContextImpl::mangleCXXVTable(
+    const CXXRecordDecl *RD, raw_ostream &Out) {
   Out << "__vt__";
   RecursiveDenest(RD, 1, getASTContext(), Out);
 }
 
-void MacintoshMangleContextImpl::mangleCXXVTT(const CXXRecordDecl *RD,
-                                              raw_ostream &Out) {
+void MacintoshMangleContextImpl::mangleCXXVTT(
+    const CXXRecordDecl *RD, raw_ostream &Out) {
   Out << "__vb__";
   RecursiveDenest(RD, 1, getASTContext(), Out);
 }
 
-void MacintoshMangleContextImpl::mangleCXXCtorVTable(const CXXRecordDecl *RD,
-                                                     int64_t Offset,
-                                                     const CXXRecordDecl *Type,
-                                                     raw_ostream &) {
+void MacintoshMangleContextImpl::mangleCXXCtorVTable(
+    const CXXRecordDecl *RD, int64_t Offset,
+    const CXXRecordDecl *Type, raw_ostream &) {
   llvm_unreachable("Can't mangle CtorVTable");
 }
 
-void MacintoshMangleContextImpl::mangleItaniumThreadLocalInit(const VarDecl *D,
-                                                              raw_ostream &) {
+void MacintoshMangleContextImpl::mangleItaniumThreadLocalInit(
+    const VarDecl *D, raw_ostream &) {
   llvm_unreachable("Can't mangle ItaniumThreadLocalInit");
 }
 
@@ -1111,19 +868,14 @@ void MacintoshMangleContextImpl::mangleCXXCtorComdat(
   llvm_unreachable("Can't mangle CtorComdat");
 }
 
-void MacintoshMangleContextImpl::mangleCXXDtorComdat(const CXXDestructorDecl *D,
-                                                     raw_ostream &) {
+void MacintoshMangleContextImpl::mangleCXXDtorComdat(
+    const CXXDestructorDecl *D, raw_ostream &) {
   llvm_unreachable("Can't mangle DtorComdat");
 }
 
 void MacintoshMangleContextImpl::mangleLambdaSig(const CXXRecordDecl *Lambda,
                                                  raw_ostream &Out) {
-  for (auto *D : Lambda->getLambdaExplicitTemplateParameters())
-    MangleTemplateParamDecl(D, getASTContext(), Out);
-  auto *Proto =
-      Lambda->getLambdaTypeInfo()->getType()->castAs<FunctionProtoType>();
-  MangleBareFunctionType(Proto, /*MangleReturnType=*/false,
-                         Lambda->getLambdaStaticInvoker(), getASTContext(), Out);
+  llvm_unreachable("Can't mangle LambdaSig");
 }
 
 void MacintoshMangleContextImpl::mangleDynamicStermFinalizer(const VarDecl *D,


### PR DESCRIPTION
Subclasses of primary bases with non standard virtual table placements don't inherit the primary base's vtable offset. This fixes that by explicitly using the primary base's vtable offset when the class having it's layout constructed is a subclass with virtual methods.